### PR TITLE
fix: upgrade to Xcode 26 / macOS 26 runner for iOS SDK 26 requirement

### DIFF
--- a/.github/workflows/build-rn-hr-dev.yml
+++ b/.github/workflows/build-rn-hr-dev.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-latest"
+          - name: "macos-26"
             os: "macos"
 
           - name: "ubuntu-latest"
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-15"
+          - name: "macos-26"
             os: "macos"
             platform: "ios"
             type: ipa
@@ -90,7 +90,7 @@ jobs:
 
       - name: 🔨 Select Xcode
         if: ${{matrix.os == 'macos'}}
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
       - name: 🔨 Load Secrets
         run: yarn load:secret

--- a/.github/workflows/build-rn-hr-pro.yml
+++ b/.github/workflows/build-rn-hr-pro.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-latest"
+          - name: "macos-26"
             os: "macos"
 
           - name: "ubuntu-latest"
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-15"
+          - name: "macos-26"
             os: "macos"
             profile: production
             platform: "ios"
@@ -97,7 +97,7 @@ jobs:
 
       - name: 🔨 Select Xcode
         if: ${{matrix.os == 'macos'}}
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
       - name: 🔨 Load Secrets
         run: yarn load:secret

--- a/.github/workflows/build-rn-hr-uat.yml
+++ b/.github/workflows/build-rn-hr-uat.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-latest"
+          - name: "macos-26"
             os: "macos"
 
           - name: "ubuntu-latest"
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "macos-15"
+          - name: "macos-26"
             os: "macos"
             platform: "ios"
             type: ipa
@@ -90,7 +90,7 @@ jobs:
 
       - name: 🔨 Select Xcode
         if: ${{matrix.os == 'macos'}}
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
       - name: 🔨 Load Secrets
         run: yarn load:secret


### PR DESCRIPTION
## Summary
- Upgrade runner from `macos-15` to `macos-26` for iOS builds
- Switch Xcode from `16.4` (iOS SDK 18.5) to `26.2` (iOS SDK 26)
- Align cache job runner to `macos-26` for consistency

Apple requires iOS SDK 26 (Xcode 26+) starting **April 28, 2026** (ITMS-90725). Both UAT and production workflows updated.

## Test plan
- [ ] Trigger a staging build (`yarn deploy` → Staging) and verify the iOS build completes on `macos-26` runner
- [ ] Verify the delivered IPA no longer triggers ITMS-90725 warning from Apple
- [ ] Verify Android builds are unaffected (still on `ubuntu-latest`)